### PR TITLE
处理以 // 开头src路径，手机无法显示

### DIFF
--- a/main.js
+++ b/main.js
@@ -107,6 +107,16 @@ class towxml {
 					data.attr.src = `${base}${data.attr.src}`;
 				};
 
+				// 处理以 // 开头src路径，手机无法显示
+				if(
+					base &&
+					data.attr && 
+					data.attr.src && 
+					data.attr.src.indexOf('//') === 0
+				){
+					data.attr.src = `http:${data.attr.src}`;
+				};
+
 				// 处理音频
 				if(data.type === 'audio'){
 					// 得到音频播放选项


### PR DESCRIPTION
像 //baidu.com/a.png 这样以 // 开头的image src路径，在小程序开发工具模拟器中可以正常显示，但是在我的手机上预览时，是加载不出来的，我把以 // 开头的路径处理为 https:// 开头，然后我在手机上预览，可以成功显示图片