### PR TITLE
fix: not parse the line break character

### DIFF
--- a/parse/index.js
+++ b/parse/index.js
@@ -62,6 +62,10 @@ const parse2 = require('./parse2/index'),
                     e = {},
                     attrs = o.attrs = item.attribs || {};
                 if(item.type === 'text'){
+                    // 不解析无意义的回车换行符
+                    if (item.data && (item.data.toString() === '\n' || item.data.toString() === '\r\n')) {
+                        return;
+                    }
                     o.text = e.text = item.data;
                 }else{
                     if(isRichTextContent){


### PR DESCRIPTION
解析时，移除对换行符和回车换行符的解析，markdown中会存在大量换行符，而解析成html或wxml时p或者text等内容无需这些无意义的换行符。不解析这些无意义的回车换行符，可减少无用标签和内容的生成，以提升渲染时性能。
以下时示例markdown文章移除对换行符解析结果的前后对比：
[
![171623336812_ pic_hd](https://user-images.githubusercontent.com/30746521/121555858-f06a8900-ca45-11eb-945c-fccbd1245df9.jpg)
](url)
![181623337371_ pic_hd](https://user-images.githubusercontent.com/30746521/121555910-fa8c8780-ca45-11eb-862a-52a95bf95418.jpg)
